### PR TITLE
switch to jdk slim base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,20 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-slim
 
 LABEL maintainer="maak.daniel@gmail.com" \
-        version="1.1.0" \
+        version="1.2.0" \
         description="Dockerimage for JDownloader2 in Headless mode"
 
 # install unrar for rar archives
-RUN apt-get update && apt-get install -y software-properties-common \
-        && apt-add-repository non-free \ 
-        && apt-get update && apt-get install -y unrar \
-        && rm -rf /var/lib/apt/lists/*
+RUN sed -i "s#deb http://deb.debian.org/debian stretch main#deb http://deb.debian.org/debian stretch main non-free#g" /etc/apt/sources.list \
+        && sed -i "s#deb http://deb.debian.org/debian stretch-updates main#deb http://deb.debian.org/debian stretch-updates main non-free#g" /etc/apt/sources.list \
+        && apt-get update && apt-get install -qy unrar 
 
-RUN mkdir -p /opt/jdownloader2/
-COPY JDownloader.jar /opt/jdownloader2/JDownloader.jar
-COPY run.sh /opt/jdownloader2/run.sh
-
-# run jdownloader during the build process
-# after the first run config directory /opt/jdownloader2/cfg is available
 WORKDIR /opt/jdownloader2/
+COPY JDownloader.jar .
+COPY run.sh .
 RUN mkdir -p /root/Downloads/ \
         && chmod +x run.sh
+        
 VOLUME [ "/root/Downloads" ]
 VOLUME [ "/opt/jdownloader2/cfg" ]
 


### PR DESCRIPTION
- Reduce image size because the openjdk jre slim images is used as base now
- Change the way of installing unrar